### PR TITLE
Feat: Split MyPy and Ruff Workflows for Faster Feedback

### DIFF
--- a/.github/workflows/lint_format_checker.yaml
+++ b/.github/workflows/lint_format_checker.yaml
@@ -1,0 +1,26 @@
+name: Lint And Format Checker.
+
+on:
+  pull_request:
+    branches: [ "*" ]
+  push:
+    branches: [ "main" ]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.11" ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Checking code formatting.
+        uses: chartboost/ruff-action@v1
+        with:
+          args: format --check
+      - name: Running linter.
+        uses: chartboost/ruff-action@v1

--- a/.github/workflows/typing_checker.yaml
+++ b/.github/workflows/typing_checker.yaml
@@ -1,47 +1,32 @@
-name: Code Quality Check
+name: Static Types Checker.
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - '*'
-
+    branches: [ "*" ]
+  push:
+    branches: [ "main" ]
 jobs:
-  pre-commit:
-
+  mypy:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
-
+        python-version: [ "3.11" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: |
             **/requirement.txt
             **/test-requirement.txt
-
-      - name: Installing dependencies.
+      - name: Install dependencies.
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirement.txt
           python -m pip install -r tests/test-requirement.txt
-
-      - name: Checking code formatting.
-        uses: chartboost/ruff-action@v1
-        with:
-          args: format --check
-
-      - name: Running linter.
-        uses: chartboost/ruff-action@v1
-
       - name: Running static types checker.
         run: |
           mypy


### PR DESCRIPTION
Separates MyPy and Ruff workflows to speed up feedback loops. If Ruff fails, it won't block MyPy, enabling quick fixes.